### PR TITLE
Upgrade workbox 3.3.1

### DIFF
--- a/app/services/service-worker.js
+++ b/app/services/service-worker.js
@@ -3,28 +3,27 @@ import Ember from 'ember';
 const { Service, computed, Evented, debug } = Ember;
 
 /*
-*
-* Service worker states:
-*    "installing" - the install event has fired, but not yet complete
-*    "installed"  - install complete
-*    "activating" - the activate event has fired, but not yet complete
-*    "activated"  - fully active
-*    "redundant"  - discarded. Either failed install, or it's been
-*                   replaced by a newer version
-*  Events triggered:
-* 		registrationComplete: sw successfully registered
-*		registrationError: sw not registered
-*		activated: new sw controlling page
-* 		waiting: new sw waiting for controlling page
-* 		updated: updated sw controlling page, need refresh
-*		unregistrationComplete: all sw are unregistered
-*/
-
+ *
+ * Service worker states:
+ *	"installing"				- the install event has fired, but is not yet completed
+ *	"installed"					- install completed
+ *	"activating"				- the activate event has fired, but is not yet completed
+ *	"activated"					- fully active
+ *	"redundant"					- discarded. Either failed install, or it's been replaced by a newer version
+ *
+ * Events triggered:
+ *	"registrationComplete"		- sw successfully registered
+ *	"registrationError"			- sw not registered
+ *	"activated"					- new sw controlling page
+ *	"waiting"					- new sw waiting for controlling page
+ *	"updated"					- updated sw controlling page, need refresh
+ *	"unregistrationComplete"	- all sw are unregistered
+ */
 export default Service.extend(Evented, {
 
 	sw: computed(() => window.navigator.serviceWorker),
 
-	isSupported: computed('sw', function () {
+	isSupported: computed('sw', function() {
 		const sw = this.get('sw');
 
 		if (sw) {
@@ -56,9 +55,9 @@ export default Service.extend(Evented, {
 	},
 
 	/*
-	* Utility function that unregisters SW, but you still need to reload to see SW removed completely
-	* This does not delete items in Cache
-	*/
+	 * Utility function that unregisters SW, but you still need to reload to see SW removed completely
+	 * This does not delete items in Cache
+	 */
 	unregisterAll() {
 		return this.get('sw').getRegistrations().then((registrations) =>
 			Promise.all(
@@ -79,9 +78,9 @@ export default Service.extend(Evented, {
 	},
 
 	/*
-	* Send message to sw in order to launch skipWaiting and clients.claim on it
-	* New sw will become active
-	*/
+	 * Send message to sw in order to launch skipWaiting and clients.claim on it
+	 * New sw will become active
+	 */
 	forceActivate(reg) {
 		this._log('Forcing serviceWorker to activate');
 		reg.waiting.postMessage('force-activate');
@@ -113,8 +112,8 @@ export default Service.extend(Evented, {
 	},
 
 	/*
-	* Listen for further changes to the new service worker's state.
-	*/
+	 * Listen for further changes to the new service worker's state.
+	 */
 	_awaitStateChange(reg) {
 		reg.installing.addEventListener('statechange', (event) => {
 			switch (event.target.state) {
@@ -148,10 +147,10 @@ export default Service.extend(Evented, {
 	},
 
 	/*
-	* This fires when the service worker controlling this page
-	* changes, eg a new worker has as skipped waiting and become
-	* the new active worker. (Notfiy new version installed)
-	*/
+	 * This fires when the service worker controlling this page
+	 * changes, eg a new worker has as skipped waiting and become
+	 * the new active worker. (Notfiy new version installed)
+	 */
 	_watchUpdates() {
 		this.get('sw').addEventListener('message', ({ data }) => {
 			if (data === 'reload-window') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6406,6 +6406,15 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -6415,15 +6424,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -9988,6 +9988,15 @@
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-template": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
@@ -10019,15 +10028,6 @@
             "ansi-regex": "3.0.0"
           }
         }
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringmap": {
@@ -10616,26 +10616,10 @@
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
-    "workbox-background-sync": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-3.1.0.tgz",
-      "integrity": "sha512-4R5zL/TJI+pUO29SMMCAa8A7EkfDt2p0/hqLeUPMFfxiMzZtAjQ9b7YL8ES6ieFBmWZbSF+PuXdHUveIkF29pA==",
-      "requires": {
-        "workbox-core": "3.1.0"
-      }
-    },
-    "workbox-broadcast-cache-update": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.1.0.tgz",
-      "integrity": "sha512-OrKUfgtEErxxVeAF6pPgy6921UrVUZsZwVNrxb1Jh30hqs1hgYUZ+CFdRrRYyfUesb/YZ54psDaBV61vEH1jbg==",
-      "requires": {
-        "workbox-core": "3.1.0"
-      }
-    },
     "workbox-build": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-3.1.0.tgz",
-      "integrity": "sha512-ZRWHlXMLpD4xRBoZba8dUIDGYIlS3bGLsFEaWylieKddAxT4ff5d4H/BFRlnMR319gJzokClfbFT+i+G1bhJ4Q==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-3.3.1.tgz",
+      "integrity": "sha512-Ttz4my45+pyaw3YUTIFB1PgJmTpvRTIs6EDna0HUYpP2H/Tcn9Z2gi7wkaApWG5qOrcp+Y+l2NqYBcrCKQ55Gg==",
       "requires": {
         "babel-runtime": "6.26.0",
         "common-tags": "1.7.2",
@@ -10644,16 +10628,18 @@
         "joi": "11.4.0",
         "lodash.template": "4.4.0",
         "pretty-bytes": "4.0.2",
-        "workbox-background-sync": "3.1.0",
-        "workbox-broadcast-cache-update": "3.1.0",
-        "workbox-cache-expiration": "3.1.0",
-        "workbox-cacheable-response": "3.1.0",
-        "workbox-core": "3.1.0",
-        "workbox-google-analytics": "3.1.0",
-        "workbox-precaching": "3.1.0",
-        "workbox-routing": "3.1.0",
-        "workbox-strategies": "3.1.0",
-        "workbox-sw": "3.1.0"
+        "workbox-background-sync": "3.3.1",
+        "workbox-broadcast-cache-update": "3.3.1",
+        "workbox-cache-expiration": "3.3.1",
+        "workbox-cacheable-response": "3.3.1",
+        "workbox-core": "3.3.1",
+        "workbox-google-analytics": "3.3.1",
+        "workbox-precaching": "3.3.1",
+        "workbox-range-requests": "3.3.1",
+        "workbox-routing": "3.3.1",
+        "workbox-strategies": "3.3.1",
+        "workbox-streams": "3.3.1",
+        "workbox-sw": "3.3.1"
       },
       "dependencies": {
         "fs-extra": {
@@ -10673,69 +10659,115 @@
           "requires": {
             "graceful-fs": "4.1.11"
           }
+        },
+        "workbox-background-sync": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-3.3.1.tgz",
+          "integrity": "sha512-BYg8Qb90apOAVOj8fR5IpWRoykTTv2eX61lV20UOYSZNkjyoZlyTMzAlW6eHmoUm4NaBVsuYwQL9EUH2ModpYQ==",
+          "requires": {
+            "workbox-core": "3.3.1"
+          }
+        },
+        "workbox-broadcast-cache-update": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.3.1.tgz",
+          "integrity": "sha512-4n7+2wSK+fOzDPcpehHTHvBh6VlgQkHPxcy/JtqK9WbMYnl6PND6At9vCJH1WdZB6z3L3WebGZM5rlpyl3uWVg==",
+          "requires": {
+            "workbox-core": "3.3.1"
+          }
+        },
+        "workbox-cache-expiration": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-3.3.1.tgz",
+          "integrity": "sha512-JCHZD9wK6TD7W2Ip7y3XgaMuZBHifK5YTpdv1g8UHsQscWU+w/GeRUsnTweTjlg1oR8LbHoMFwGMA0y/rzgeWA==",
+          "requires": {
+            "workbox-core": "3.3.1"
+          }
+        },
+        "workbox-cacheable-response": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-3.3.1.tgz",
+          "integrity": "sha512-0Qo2l5QFaPxJmFfUrgPFTPMYuZb6FpBmAJtjQjJKqfs5DhZquiIgfTVIAKn2R232z56ngPDOJbw6NUTWKfGIJg==",
+          "requires": {
+            "workbox-core": "3.3.1"
+          }
+        },
+        "workbox-core": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-3.3.1.tgz",
+          "integrity": "sha512-SG/Go59lYrumQUE4wOfKs0+Qt2SABR3jJn/dqsOY9DQxTXRYFvT9ZMziC/BbR2eks0r8G+iVWlQvdEHpZCnBCg=="
+        },
+        "workbox-google-analytics": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-3.3.1.tgz",
+          "integrity": "sha512-d3cqejBKDsLFEoWlgFTi6E+3p7VDk5CJXaQd7fX7oTKCrz4OYG+xrhH5k/Qjw68rwwl/5nKJInlH+OQUObKKUw==",
+          "requires": {
+            "workbox-background-sync": "3.3.1",
+            "workbox-core": "3.3.1",
+            "workbox-routing": "3.3.1",
+            "workbox-strategies": "3.3.1"
+          }
+        },
+        "workbox-precaching": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-3.3.1.tgz",
+          "integrity": "sha512-hKkJaIF/Q1QMysp7ErmtQKvPbFoWcr5q8BnjK2iGu61JtObq+Hqgan5lE3YL9QLZu1lI4n11cESIi1fAOXmmfA==",
+          "requires": {
+            "workbox-core": "3.3.1"
+          }
+        },
+        "workbox-routing": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-3.3.1.tgz",
+          "integrity": "sha512-3858dhIbIv6aKooqm9z6CZvCSSByZKlM8KQi3AQlEg+Vsby/hOYhT0gKHZcc42uqwxtfFKVV6a8xX0zrzc9TKg==",
+          "requires": {
+            "workbox-core": "3.3.1"
+          }
+        },
+        "workbox-strategies": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-3.3.1.tgz",
+          "integrity": "sha512-HgT0UY5PJo9/BDs6ExFSSBlkdoLT6AVa5smk2MiOeubRMc28YDvWBn3QIldelVRKjKLnnKo7MtwiLn9G9l0MUg==",
+          "requires": {
+            "workbox-core": "3.3.1"
+          }
+        },
+        "workbox-sw": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-3.3.1.tgz",
+          "integrity": "sha512-6U9UW52L/jCdJNQNMlST5nM0DUy7e8lFBzuL6YG7z3VEQJ40bnKfCmdrQ9shZ6qZW/UwEiDp4KhAUMYTr/pZxA=="
         }
       }
     },
-    "workbox-cache-expiration": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-3.1.0.tgz",
-      "integrity": "sha512-M958TkpSGNCZM09N9aACZkjsStbFlkRYJ/jCjKLU/Xn3oJKn+R/8RXpcsk6bO5IG3Xbb5wFGH4fKtn7MTwCBBg==",
+    "workbox-range-requests": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-3.3.1.tgz",
+      "integrity": "sha512-IA9yieHKHsmZRWOUxGEYX8AYXhgMT1QfIO2ADanMIBX7ojmAOsr4OJYgCzsB9v2T7QhqSH4lFipzw+wxCJ7y5g==",
       "requires": {
-        "workbox-core": "3.1.0"
+        "workbox-core": "3.3.1"
+      },
+      "dependencies": {
+        "workbox-core": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-3.3.1.tgz",
+          "integrity": "sha512-SG/Go59lYrumQUE4wOfKs0+Qt2SABR3jJn/dqsOY9DQxTXRYFvT9ZMziC/BbR2eks0r8G+iVWlQvdEHpZCnBCg=="
+        }
       }
     },
-    "workbox-cacheable-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-3.1.0.tgz",
-      "integrity": "sha512-Mv8oV0jpDFkJ0cqTcXBVClR/NE+xxlkUi4ei1nbI/H2T/rvo4HvXCgRU2STdvv+3z59Em+t4PuHPhwM4gMshoA==",
+    "workbox-streams": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-3.3.1.tgz",
+      "integrity": "sha512-xjwZMX6MVCFv7tV7kcgfNZCW1vrR2o8iZ8DGpcUQBYT/7Vqw0QHXfflBM7AJkTYQsdWRKeyIXGvuxt5LOEGcoQ==",
       "requires": {
-        "workbox-core": "3.1.0"
+        "workbox-core": "3.3.1"
+      },
+      "dependencies": {
+        "workbox-core": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-3.3.1.tgz",
+          "integrity": "sha512-SG/Go59lYrumQUE4wOfKs0+Qt2SABR3jJn/dqsOY9DQxTXRYFvT9ZMziC/BbR2eks0r8G+iVWlQvdEHpZCnBCg=="
+        }
       }
-    },
-    "workbox-core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-3.1.0.tgz",
-      "integrity": "sha512-AR/p3fOpe9frDt/PEO2tHUNCQFG921DnCeP0dulwvyvlriYubT8L2yxIWdiiZrA+kXEzYwfC89XicIoJNInGNw=="
-    },
-    "workbox-google-analytics": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-3.1.0.tgz",
-      "integrity": "sha512-lD9H/hLj9VKdexw/LsdM8JZ2ZW2HM7Hf9lcVkpeSRuuh5BmpUUl3fTvQZyQqYFW4exKjtI3M4l/kEF7oMM6vWw==",
-      "requires": {
-        "workbox-background-sync": "3.1.0",
-        "workbox-core": "3.1.0",
-        "workbox-routing": "3.1.0",
-        "workbox-strategies": "3.1.0"
-      }
-    },
-    "workbox-precaching": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-3.1.0.tgz",
-      "integrity": "sha512-lFhL+RN86gLOKnlQO4p5I8oH3axY1RrS3wIUyi8n6Hvn9xNc4ZmQFyjwrJNMBQBe2MImeLe90tGMTElKVBaXfg==",
-      "requires": {
-        "workbox-core": "3.1.0"
-      }
-    },
-    "workbox-routing": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-3.1.0.tgz",
-      "integrity": "sha512-OZgCZ3wbo/jNvm0sJIqFiNuQz87FFQYCXlFzL/klCn7X6BrAYM+5f2gbtSDSmpzqgfK858jSBsyEQr7ech6+FQ==",
-      "requires": {
-        "workbox-core": "3.1.0"
-      }
-    },
-    "workbox-strategies": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-3.1.0.tgz",
-      "integrity": "sha512-fJJZEKDhZE7FKMhUUxpGkoMQGuTlDhv3x1Y6/DTG1piTM2wltyMxRKJvm62cx+EJPQ7f0Cu4uYanQiFJB7aGkA==",
-      "requires": {
-        "workbox-core": "3.1.0"
-      }
-    },
-    "workbox-sw": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-3.1.0.tgz",
-      "integrity": "sha512-A4cPW0JFKP5NRjA1r5ZrslCaes3EggV/gSWXLw/TTj6MlAxo9XmDCRdJ8pabfz8B+Zd/v/r1d7tdQK5OhitYyg=="
     },
     "workerpool": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ember-cli-babel": "^6.3.0",
     "pretty-bytes": "^4.0.2",
     "rimraf": "^2.6.2",
-    "workbox-build": "3.1.0",
+    "workbox-build": "3.3.1",
     "glob": "^7.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
- Upgrade `workbox-build` dependency to [v3.3.1](https://github.com/GoogleChrome/workbox/releases/tag/v3.3.1) to enable usage of `purgeOnQuotaError` flag.
- Minimal code improvements 