### PR TITLE
Add purgeOnDisable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ If you need to customize **ember-cli-workbox configuration** you can do it like 
 
 ENV['ember-cli-workbox'] = {
   enabled: environment !== 'test',
-  debug: true
+  debug: true,
+  purgeOnDisable: true
 };
 ```
 
 - `enabled` - (Boolean) Addon is enabled. Default to true on production builds
 - `debug` - (Boolean) Log serviceworker states (registering, updating, etc)
+- `purgeOnDisable` - (Boolean) If the addon is disabled, purges the cache. Defaults to `false`
 
 You can further customize ember-cli-workbox by setting **workbox configurations** in your environment.js file:
 
@@ -113,10 +115,10 @@ See this complete example for this implementation:
 
 ```javascript
 // <my-app>/mixins/service-worker-states.js
-   
+
 import Ember from 'ember';
 
-const { 
+const {
   inject: { service },
   Mixin
 } = Ember;
@@ -129,25 +131,25 @@ const {
  */
 export default Mixin.create({
 
-  serviceWorker: service(), 
- 
+  serviceWorker: service(),
+
   /**
    * Mixin initialization
    *
    * @method init
    */
   init() {
-  	this._super(...arguments);  
+  	this._super(...arguments);
   	this.subscribeToSWEvents();
-  }, 
- 
+  },
+
   /**
    * Subscribe to session events
    *
    * @method subscribeToSWEvents
    */
   subscribeToSWEvents() {
-    const sw = this.get('serviceWorker'); 
+    const sw = this.get('serviceWorker');
     sw.on('activated', (reg) => {
       window.alert('Content is now available offline!')
   	});
@@ -160,7 +162,7 @@ export default Mixin.create({
   		window.location.reload();
   		console.log('New version installed');
   	});
-  }  
+  }
 });
 ```
 
@@ -171,7 +173,7 @@ import ApplicationSwMixin from '<my-app>/mixins/service-worker-states';
 
 export default Route.extend(ApplicationSwMixin,{
   ....
-} 
+}
 ```
 
 ## Prevent caching lazy engines

--- a/app/instance-initializers/sw.js
+++ b/app/instance-initializers/sw.js
@@ -1,6 +1,5 @@
-import Ember from 'ember';
-
-const { getWithDefault, debug } = Ember;
+import { get } from '@ember/object';
+import { warn } from '@ember/debug';
 
 export function initialize(appInstance) {
 	const config = appInstance.resolveRegistration('config:environment');
@@ -26,7 +25,7 @@ export function initialize(appInstance) {
 			});
 		}
 	} else {
-		debug('Service workers are not supported in this browser.');
+		warn('Service workers are not supported in this browser.');
 	}
 }
 

--- a/app/instance-initializers/sw.js
+++ b/app/instance-initializers/sw.js
@@ -18,7 +18,13 @@ export function initialize(appInstance) {
 		if (isEnabled) {
 			swService.register(swDestFile);
 		} else {
-			swService.unregisterAll();
+			swService.unregisterAll().then(() => {
+				const purgeOnDisable = getWithDefault(config, 'ember-cli-workbox.purgeOnDisable', false);
+
+				if (purgeOnDisable) {
+					swService.purgeCache();
+				}
+			});
 		}
 	} else {
 		debug('Service workers are not supported in this browser.');

--- a/app/instance-initializers/sw.js
+++ b/app/instance-initializers/sw.js
@@ -4,10 +4,9 @@ const { getWithDefault, debug } = Ember;
 
 export function initialize(appInstance) {
 	const config = appInstance.resolveRegistration('config:environment');
-	const isProdBuild = config.environment === 'production';
-	const isEnabled = getWithDefault(config, 'ember-cli-workbox.enabled', isProdBuild);
-	const debugAddon = getWithDefault(config, 'ember-cli-workbox.debug', !isProdBuild);
-	const swDestFile = getWithDefault(config, 'workbox.swDest', 'sw.js');
+	const isEnabled = get(config, 'ember-cli-workbox.enabled');
+	const debugAddon = get(config, 'ember-cli-workbox.debug');
+	const swDestFile = get(config, 'workbox.swDest');
 	const swService = appInstance.lookup('service:service-worker');
 
 	swService.set('debug', debugAddon);
@@ -19,7 +18,7 @@ export function initialize(appInstance) {
 			swService.register(swDestFile);
 		} else {
 			swService.unregisterAll().then(() => {
-				const purgeOnDisable = getWithDefault(config, 'ember-cli-workbox.purgeOnDisable', false);
+				const purgeOnDisable = get(config, 'ember-cli-workbox.purgeOnDisable');
 
 				if (purgeOnDisable) {
 					swService.purgeCache();

--- a/app/services/service-worker.js
+++ b/app/services/service-worker.js
@@ -21,6 +21,8 @@ const { Service, computed, Evented, debug } = Ember;
  */
 export default Service.extend(Evented, {
 
+	caches: computed(() => window.caches),
+
 	sw: computed(() => window.navigator.serviceWorker),
 
 	isSupported: computed('sw', function() {
@@ -74,6 +76,19 @@ export default Service.extend(Evented, {
 		).then(() => {
 			this.trigger('unregistrationComplete');
 			this._log('Unregistrations complete');
+		});
+	},
+
+	/*
+	 * Delete caches
+	 */
+	purgeCache() {
+		const _caches = this.get('caches');
+
+		return _caches.keys().then((cacheNames = []) => {
+			cacheNames.forEach((name) => {
+				_caches.delete(name);
+			});
 		});
 	},
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ module.exports = {
 
 		mergeOptions(options, {
 			enabled: isProdBuild,
-			debug: !isProdBuild
+			debug: !isProdBuild,
+			purgeOnDisable: false
 		});
 
 		this.options = options;

--- a/tests/acceptance/simple-test.js
+++ b/tests/acceptance/simple-test.js
@@ -54,3 +54,14 @@ test('it unregisters sw', function(assert) {
 	});
 });
 
+test('it purges caches', function(assert) {
+	const _caches = this.swService.get('caches');
+
+	return _caches.open('dummy').then(() =>
+		this.swService.purgeCache()
+	).then(() =>
+		_caches.keys()
+	).then((keys) => {
+		assert.notOk(keys.length, 'Cache purged');
+	});
+});


### PR DESCRIPTION
Adds the `purgeOnDisable` option to delete caches after unregistering the serviceworker (when the addon is disabled after having been previously enabled).