### PR TITLE
Add importScriptsTransform option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ If you need to customize **ember-cli-workbox configuration** you can do it like 
 ENV['ember-cli-workbox'] = {
   enabled: environment !== 'test',
   debug: true,
-  autoRegister: true
+  autoRegister: true,
+  importScriptsTransform: (importScripts) => {
+    return importScripts.map((importScript) => {
+      return `https://example-cdn.com/${importScript}`;
+    }
+  }
 };
 ```
 
@@ -48,6 +53,7 @@ ENV['ember-cli-workbox'] = {
 | `enabled`      | `Boolean` | Addon is enabled. Default to true on production builds         |
 | `debug`        | `Boolean` | Log serviceworker states (registering, updating, etc)          |
 | `autoRegister` | `Boolean` | Enable the sw registration before initializing the application |
+| `importScriptsTransform` | `Function` | Allows for transformation of array sent to workbox [importScripts](https://developers.google.com/web/tools/workbox/modules/workbox-build#generateSW-importScripts) |
 
 You can further customize ember-cli-workbox by setting **workbox configurations** in your environment.js file:
 

--- a/lib/broccoli-workbox.js
+++ b/lib/broccoli-workbox.js
@@ -60,6 +60,10 @@ BroccoliWorkbox.prototype.build = function() {
 
 	workboxOptions.importScripts = filesToIncludeInSW;
 
+	if (this.options.importScriptsTransform) {
+		workboxOptions.importScripts = this.options.importScriptsTransform(workboxOptions.importScripts);
+	}
+
 	return cleanPromise.then(() =>
 		workboxBuild.generateSW(workboxOptions).then(({ count, size }) => {
 			debug(blue('Service worker successfully generated.'));

--- a/node-tests/default-config.js
+++ b/node-tests/default-config.js
@@ -6,6 +6,11 @@ module.exports = function(environment) {
 		environment,
 		baseURL: '/',
 		locationType: 'auto',
+		'ember-cli-workbox': {
+			importScriptsTransform(importScripts) {
+				return importScripts.map((importScript) => process.env.IMPORT_SCRIPTS_PREFIX + importScript);
+			}
+		},
 		EmberENV: {
 			FEATURES: {
 				// Here you can enable experimental features on an ember canary build

--- a/node-tests/index.js
+++ b/node-tests/index.js
@@ -12,6 +12,9 @@ const fixturePath = path.resolve(__dirname, '..');
 const outputSWPath = outputFilePath('sw.js');
 const configPath = path.resolve(fixturePath, 'tests/dummy/config');
 
+// Using process.env to be accessible independent of file location
+process.env.IMPORT_SCRIPTS_PREFIX = '2d57274b-581a-4017-9b88-7f0f04b2d1a1';
+
 function runEmberCommand(packagePath, command) {
 	return new Promise((resolve, reject) =>
 		exec(`${emberCLIPath} ${command}`, {
@@ -83,6 +86,10 @@ describe('Addon is enabled for production build', function() {
 		it('produces a sw skip waiting file, which is imported on sw.js', () => {
 			assertFileExists(outputFilePath('assets/service-workers/skip-waiting.js'));
 			assertContains(outputSWPath, /"assets\/service-workers\/skip-waiting.js"/);
+		});
+
+		it('applies importScriptsTransform', () => {
+			assertContains(outputSWPath, process.env.IMPORT_SCRIPTS_PREFIX);
 		});
 	});
 });


### PR DESCRIPTION
It looks like `importScripts` are indiscriminately overwritten here: https://github.com/BBVAEngineering/ember-cli-workbox/blob/master/lib/broccoli-workbox.js#L57-L61

I needed to prefix all imported scripts with our own cdn origin so I came up with a `importScriptsTransform` option (modeled after the workbox [manifestTransforms option](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.ManifestTransform)).

So with this you can supply a function to transform the importScripts. Ex:

```js
  ENV['ember-cli-workbox'] = {
    enabled: true,
    autoRegister: true,
    importScriptsTransform: importScripts => {
      return importScripts.map(importScript => {
        return process.env.EMBER_ASSETS_ROOT_PATH + importScript;
      });
    },
  };
```