### PR TITLE
Do not start empty service worker if disabled

### DIFF
--- a/lib/broccoli-workbox.js
+++ b/lib/broccoli-workbox.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 /* eslint-disable no-sync */
 const glob = require('glob');
 const fs = require('fs');
@@ -34,29 +35,46 @@ function BroccoliWorkbox(inputNodes, config) {
 	this.workboxOptions = config.workboxOptions;
 }
 
+BroccoliWorkbox.prototype.removeServiceWorker = function(filePath) {
+	if (fs.existsSync(filePath)) {
+		debug(yellow('Addon disabled. Service worker exist, remove it'));
+		fs.unlinkSync(filePath);
+	}
+};
+
 BroccoliWorkbox.prototype.build = function() {
 	const workboxOptions = Object.assign({}, this.workboxOptions);
 	const directory = this.inputPaths[0];
 
-	if (!this.options.enabled) {
-		debug(yellow('Addon disabled. Generating empty service worker...'));
-		workboxOptions.globPatterns = [];
-		workboxOptions.runtimeCaching = [];
-	}
-
-	workboxOptions.globDirectory = path.join(directory, workboxOptions.globDirectory);
 	workboxOptions.swDest = path.join(directory, workboxOptions.swDest);
 
+	if (!this.options.enabled) {
+		debug(yellow('Addon disabled. Disable and remove service worker...'));
+		this.removeServiceWorker(workboxOptions.swDest);
+		return false;
+	}
+
+	workboxOptions.globDirectory = path.join(
+		directory,
+		workboxOptions.globDirectory
+	);
+
 	let cleanPromise = Promise.resolve();
-	const workboxDirectory = path.join(directory, `workbox-v${workboxBuildPkg.version}`);
+	const workboxDirectory = path.join(
+		directory,
+		`workbox-v${workboxBuildPkg.version}`
+	);
 
 	// Remove workbox libraries directory to prevent exception on recopying it.
-	if (!workboxOptions.importWorkboxFromCDN && fs.existsSync(workboxDirectory)) {
+	if (
+		!workboxOptions.importWorkboxFromCDN &&
+		fs.existsSync(workboxDirectory)
+	) {
 		cleanPromise = cleanDir(workboxDirectory);
 	}
-	const filesToIncludeInSW = glob.sync('assets/service-workers/*.js',
-		{ cwd: workboxOptions.globDirectory }
-	);
+	const filesToIncludeInSW = glob.sync('assets/service-workers/*.js', {
+		cwd: workboxOptions.globDirectory
+	});
 
 	workboxOptions.importScripts = filesToIncludeInSW;
 


### PR DESCRIPTION
When plugin disabled dont start an empty service worker. The service worker touches swDest file and causes live reload to do a full page refresh even if the addon is disabled.

By not starting a service worker fixes this issue.

Fixes #78 