### PR TITLE
feat(lib/broccoli-workbox.js): added generator warnings

### DIFF
--- a/lib/broccoli-workbox.js
+++ b/lib/broccoli-workbox.js
@@ -10,7 +10,7 @@ const workboxBuild = require('workbox-build');
 const workboxBuildPkg = require('workbox-build/package.json');
 const rimraf = require('rimraf');
 const chalk = require('chalk');
-const { red, blue, yellow } = chalk;
+const { red, green, yellow } = chalk;
 
 function cleanDir(directory) {
 	return new Promise((resolve, reject) =>
@@ -45,10 +45,14 @@ class BroccoliWorkbox extends Plugin {
 		try {
 			await cleanPromise;
 
-			const { count, size } = await workboxBuild.generateSW(workboxOptions);
+			const { count, size, warnings } = await workboxBuild.generateSW(workboxOptions);
 
-			debug(blue('Service worker successfully generated.'));
-			debug(blue(`${count} files will be precached, totalling ${prettyBytes(size)}.`));
+			debug(green('Service worker successfully generated.'));
+			debug(green(`${count} files will be precached, totalling ${prettyBytes(size)}.`));
+			
+			if (warnings) {
+				debug(yellow(warnings));
+			}
 		} catch (e) {
 			debug(red(`Could not generate service Worker ${e.name}`));
 
@@ -59,7 +63,7 @@ class BroccoliWorkbox extends Plugin {
 	async build() {
 		const workboxOptions = Object.assign({}, this.workboxOptions);
 		const directory = this.inputPaths[0];
-
+		
 		workboxOptions.swDest = path.join(directory, workboxOptions.swDest);
 
 		if (!this.options.enabled) {
@@ -69,7 +73,7 @@ class BroccoliWorkbox extends Plugin {
 
 			return false;
 		}
-
+		
 		workboxOptions.globDirectory = path.join(
 			directory,
 			workboxOptions.globDirectory
@@ -91,7 +95,7 @@ class BroccoliWorkbox extends Plugin {
 		});
 
 		workboxOptions.importScripts = filesToIncludeInSW;
-
+		
 		if (this.options.importScriptsTransform) {
 			workboxOptions.importScripts = this.options.importScriptsTransform(workboxOptions.importScripts);
 		}


### PR DESCRIPTION
I know it's minor, but these things helped me track down why one of my files were not showing up in my service-worker precache.

- Added generator warnings from workbox-build.
- Changed success messages green for wider visual Accessibility.