### PR TITLE
Add workaround for creating sw.js file for embroider project

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,6 +88,13 @@ module.exports = {
       return tree;
     }
 
-    this._processTree(tree);
+    const workboxFunnel = new BroccoliWorkbox([tree], {
+      options: this._options,
+      workboxOptions: this.workboxOptions,
+    });
+
+    return mergeTrees([tree, workboxFunnel], {
+      overwrite: true,
+    });
   },
 };

--- a/index.js
+++ b/index.js
@@ -58,11 +58,21 @@ module.exports = {
     }
   },
 
-  postprocessTree(type, tree) {
-    if (type !== 'all') {
-      return tree;
+  processTree(app, tree) {
+    let emberCliWorkboxAddon = app.project.addons.find(
+      ({ name }) => name === 'ember-cli-workbox'
+    );
+
+    if (!emberCliWorkboxAddon) {
+      throw new Error(
+        "Could not find initialized ember-cli-workbox addon. It must be part of your app's dependencies!"
+      );
     }
 
+    return emberCliWorkboxAddon._processTree(tree);
+  },
+
+  _processTree(tree) {
     const workboxFunnel = new BroccoliWorkbox([tree], {
       options: this._options,
       workboxOptions: this.workboxOptions,
@@ -71,5 +81,13 @@ module.exports = {
     return mergeTrees([tree, workboxFunnel], {
       overwrite: true,
     });
+  },
+
+  postprocessTree(type, tree) {
+    if (type !== 'all') {
+      return tree;
+    }
+
+    this._processTree(tree);
   },
 };


### PR DESCRIPTION
I've taken the inspiration from [prember](https://github.com/ef4/prember#using-prember-with-embroider) which mentioned that embroider based projects don't support postprocessTree hook of type 'all' and hence we need a way to manually call the function that generates the file.
This fixes https://github.com/BBVAEngineering/ember-cli-workbox/issues/122